### PR TITLE
Add homebrew cask install to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,6 @@
 - Get your personal API key for openweathermap here: http://openweathermap.org/appid . 
 - Add your key in Keys.plist. 
 
-[Download latest release](https://github.com/inderdhir/DatWeatherDoe/releases/latest)
+[Download latest release](https://github.com/inderdhir/DatWeatherDoe/releases/latest) or install via Homebrew Cask:
+
+    brew cask install datweatherdoe


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-cask/pull/78847

DatWeatherDoe got added to Homebrew Cask, so it can be installed and updated via the command line