### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 [Download latest release](https://github.com/inderdhir/DatWeatherDoe/releases/latest) or install via Homebrew Cask:
 
-    brew cask install datweatherdoe
+    brew install --cask datweatherdoe
 
 ## Using Location Services
 


### PR DESCRIPTION
Fix error when installing using latest Homebrew. Just fix README.md.

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103059100-7d7c6b80-45e7-11eb-9505-de96220525f5.png)