### PR TITLE
fix the close issue of configuration window

### DIFF
--- a/DatWeatherDoe/ConfigureViewController.swift
+++ b/DatWeatherDoe/ConfigureViewController.swift
@@ -78,7 +78,7 @@ class ConfigureViewController: NSViewController, NSTextFieldDelegate {
         DefaultsManager.shared.unit = fahrenheitRadioButton.state == .on ? .fahrenheit : .celsius
         DefaultsManager.shared.usingLocation = useLocationToggleCheckBox.state == .on
         (NSApplication.shared.delegate as? AppDelegate)?.getWeather(nil)
-
-        view.window?.close()
+        // close the popover
+        (NSApplication.shared.delegate as? AppDelegate)?.togglePopover(sender)
     }
 }


### PR DESCRIPTION
When we show configuration window and click "Done" button, the next menu click of "Configure" will not show the
configuration window until user clicks "Configure" one more time. Fix it by using the togglePopover function directly
in ConfigureViewController.