### PR TITLE
feat: allow hiding unit letter and symbol (separately each)

### DIFF
--- a/DatWeatherDoe/AppDelegate.swift
+++ b/DatWeatherDoe/AppDelegate.swift
@@ -82,13 +82,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 extension AppDelegate: WeatherViewModelDelegate {
     func didUpdateWeatherData(_ data: WeatherData) {
         viewModel.updateCityWith(cityId: data.cityId)
-        
+
         let measurementUnit = MeasurementUnit(rawValue: configManager.measurementUnit) ?? .imperial
         menuBarManager.updateMenuBarWith(
             weatherData: data,
             options: .init(
                 unit: measurementUnit,
-                isRoundingOff: configManager.isRoundingOffData
+                isRoundingOff: configManager.isRoundingOffData,
+                isUnitLetterOff: configManager.isUnitLetterOff,
+                isUnitSymbolOff: configManager.isUnitSymbolOff
             )
         )
     }

--- a/DatWeatherDoe/Config/ConfigManager.swift
+++ b/DatWeatherDoe/Config/ConfigManager.swift
@@ -16,6 +16,8 @@ protocol ConfigManagerType: AnyObject {
     var isShowingWeatherIcon: Bool { get set }
     var isShowingHumidity: Bool { get set }
     var isRoundingOffData: Bool { get set }
+    var isUnitLetterOff: Bool { get set }
+    var isUnitSymbolOff: Bool { get set }
     var isWeatherConditionAsTextEnabled: Bool { get set }
 }
 
@@ -29,6 +31,8 @@ final class ConfigManager: ConfigManagerType {
         case isShowingWeatherIcon
         case isShowingHumidity
         case isRoundingOffData
+        case isUnitLetterOff
+        case isUnitSymbolOff
         case isWeatherConditionAsTextEnabled
     }
 
@@ -61,6 +65,12 @@ final class ConfigManager: ConfigManagerType {
 
     @Storage(key: DefaultsKeys.isRoundingOffData.rawValue, defaultValue: false)
     public var isRoundingOffData: Bool
+
+    @Storage(key: DefaultsKeys.isUnitLetterOff.rawValue, defaultValue: false)
+    public var isUnitLetterOff: Bool
+
+    @Storage(key: DefaultsKeys.isUnitSymbolOff.rawValue, defaultValue: false)
+    public var isUnitSymbolOff: Bool
 
     @Storage(
         key: DefaultsKeys.isWeatherConditionAsTextEnabled.rawValue,

--- a/DatWeatherDoe/UI/Configure/ConfigurationCommitter.swift
+++ b/DatWeatherDoe/UI/Configure/ConfigurationCommitter.swift
@@ -23,11 +23,15 @@ final class ConfigurationCommitter {
         refreshInterval: RefreshInterval,
         isShowingHumidity: Bool,
         isRoundingOffData: Bool,
+        isUnitLetterOff: Bool,
+        isUnitSymbolOff: Bool,
         isWeatherConditionAsTextEnabled: Bool
     ) {
         configManager.refreshInterval = refreshInterval.rawValue
         configManager.isShowingHumidity = isShowingHumidity
         configManager.isRoundingOffData = isRoundingOffData
+        configManager.isUnitLetterOff = isUnitLetterOff
+        configManager.isUnitSymbolOff = isUnitSymbolOff
         configManager.isWeatherConditionAsTextEnabled = isWeatherConditionAsTextEnabled
     }
 }

--- a/DatWeatherDoe/UI/Configure/ConfigureView.swift
+++ b/DatWeatherDoe/UI/Configure/ConfigureView.swift
@@ -79,6 +79,18 @@ struct ConfigureView: View {
                 }
                 
                 HStack {
+                    Text(LocalizedStringKey("Hide unit letter"))
+                    Spacer()
+                    Toggle(isOn: $viewModel.isUnitLetterOff) {}
+                }
+
+                HStack {
+                    Text(LocalizedStringKey("Hide unit ° symbol"))
+                    Spacer()
+                    Toggle(isOn: $viewModel.isUnitSymbolOff) {}
+                }
+
+                HStack {
                     Text(LocalizedStringKey("Weather Condition (as text)"))
                     Spacer()
                     Toggle(isOn: $viewModel.isWeatherConditionAsTextEnabled) {}

--- a/DatWeatherDoe/UI/Configure/ConfigureViewModel.swift
+++ b/DatWeatherDoe/UI/Configure/ConfigureViewModel.swift
@@ -57,6 +57,18 @@ final class ConfigureViewModel: ObservableObject {
         }
     }
 
+    @Published var isUnitLetterOff: Bool {
+        didSet {
+            configManager.isUnitLetterOff = isUnitLetterOff
+        }
+    }
+
+    @Published var isUnitSymbolOff: Bool {
+        didSet {
+            configManager.isUnitSymbolOff = isUnitSymbolOff
+        }
+    }
+
     @Published var isWeatherConditionAsTextEnabled: Bool {
         didSet {
             configManager.isWeatherConditionAsTextEnabled = isWeatherConditionAsTextEnabled
@@ -86,6 +98,8 @@ final class ConfigureViewModel: ObservableObject {
         isShowingWeatherIcon = configManager.isShowingWeatherIcon
         isShowingHumidity = configManager.isShowingHumidity
         isRoundingOffData = configManager.isRoundingOffData
+        isUnitLetterOff = configManager.isUnitLetterOff
+        isUnitSymbolOff = configManager.isUnitSymbolOff
         isWeatherConditionAsTextEnabled = configManager.isWeatherConditionAsTextEnabled
 
         updateWeatherSource()
@@ -116,6 +130,8 @@ final class ConfigureViewModel: ObservableObject {
             refreshInterval: refreshInterval,
             isShowingHumidity: isShowingHumidity,
             isRoundingOffData: isRoundingOffData,
+            isUnitLetterOff: isUnitLetterOff,
+            isUnitSymbolOff: isUnitSymbolOff,
             isWeatherConditionAsTextEnabled: isWeatherConditionAsTextEnabled
         )
     }

--- a/DatWeatherDoe/UI/Decorator/Text/Temperature/TemperatureForecastTextBuilder.swift
+++ b/DatWeatherDoe/UI/Decorator/Text/Temperature/TemperatureForecastTextBuilder.swift
@@ -43,7 +43,9 @@ final class TemperatureForecastTextBuilder {
         TemperatureHelpers.getTemperatureWithDegrees(
             temperature,
             unit: options.unit,
-            isRoundingOff: options.isRoundingOff
+            isRoundingOff: options.isRoundingOff,
+            isUnitLetterOff: options.isUnitLetterOff,
+            isUnitSymbolOff: options.isUnitSymbolOff
         )
     }
 }

--- a/DatWeatherDoe/UI/Decorator/Text/Temperature/TemperatureFormatter.swift
+++ b/DatWeatherDoe/UI/Decorator/Text/Temperature/TemperatureFormatter.swift
@@ -17,7 +17,10 @@ final class TemperatureFormatter {
         return formatter
     }()
     
-    func getFormattedTemperatureString(_ temperature: Double, isRoundingOff: Bool) -> String? {
+    func getFormattedTemperatureString(_ temperature: Double,
+                                       isRoundingOff: Bool,
+                                       isUnitLetterOff: Bool,
+                                       isUnitSymbolOff: Bool) -> String? {
         setupTemperatureRounding(isRoundingOff: isRoundingOff)
         return formatTemperatureString(temperature)
     }

--- a/DatWeatherDoe/UI/Decorator/Text/Temperature/TemperatureFormatter.swift
+++ b/DatWeatherDoe/UI/Decorator/Text/Temperature/TemperatureFormatter.swift
@@ -18,9 +18,7 @@ final class TemperatureFormatter {
     }()
     
     func getFormattedTemperatureString(_ temperature: Double,
-                                       isRoundingOff: Bool,
-                                       isUnitLetterOff: Bool,
-                                       isUnitSymbolOff: Bool) -> String? {
+                                       isRoundingOff: Bool) -> String? {
         setupTemperatureRounding(isRoundingOff: isRoundingOff)
         return formatTemperatureString(temperature)
     }

--- a/DatWeatherDoe/UI/Decorator/Text/Temperature/TemperatureHelpers.swift
+++ b/DatWeatherDoe/UI/Decorator/Text/Temperature/TemperatureHelpers.swift
@@ -41,9 +41,7 @@ final class TemperatureHelpers {
     ) -> String? {
         TemperatureFormatter().getFormattedTemperatureString(
             temperature,
-            isRoundingOff: isRoundingOff,
-            isUnitLetterOff: isUnitLetterOff,
-            isUnitSymbolOff: isUnitSymbolOff
+            isRoundingOff: isRoundingOff
         )
     }
 

--- a/DatWeatherDoe/UI/Decorator/Text/Temperature/TemperatureHelpers.swift
+++ b/DatWeatherDoe/UI/Decorator/Text/Temperature/TemperatureHelpers.swift
@@ -12,35 +12,59 @@ final class TemperatureHelpers {
     class func getTemperatureWithDegrees(
         _ temperature: Double,
         unit: TemperatureUnit,
-        isRoundingOff: Bool
+        isRoundingOff: Bool,
+        isUnitLetterOff: Bool,
+        isUnitSymbolOff: Bool
     ) -> String? {
         guard let temperatureString = getFormattedString(
             temperature: temperature,
-            isRoundingOff: isRoundingOff
+            isRoundingOff: isRoundingOff,
+            isUnitLetterOff: isUnitLetterOff,
+            isUnitSymbolOff: isUnitSymbolOff
         ) else {
             return nil
         }
         
         return combineTemperatureWithUnitDegrees(
             temperature: temperatureString,
-            unit: unit.unitString
+            unit: unit.unitString,
+            isUnitLetterOff: isUnitLetterOff,
+            isUnitSymbolOff: isUnitSymbolOff
         )
     }
     
     private class func getFormattedString(
         temperature: Double,
-        isRoundingOff: Bool
+        isRoundingOff: Bool,
+        isUnitLetterOff: Bool,
+        isUnitSymbolOff: Bool
     ) -> String? {
         TemperatureFormatter().getFormattedTemperatureString(
             temperature,
-            isRoundingOff: isRoundingOff
+            isRoundingOff: isRoundingOff,
+            isUnitLetterOff: isUnitLetterOff,
+            isUnitSymbolOff: isUnitSymbolOff
         )
     }
-    
+
     private class func combineTemperatureWithUnitDegrees(
         temperature: String,
-        unit: String
+        unit: String,
+        isUnitLetterOff: Bool,
+        isUnitSymbolOff: Bool
     ) -> String {
-        [temperature, unit].joined(separator: degreeString)
+        if isUnitLetterOff {
+            if isUnitSymbolOff {
+                return [temperature,   ""].joined(separator: ""          )
+            } else {
+                return [temperature,   ""].joined(separator: degreeString)
+            }
+        } else {
+            if isUnitSymbolOff {
+                return [temperature, unit].joined(separator: ""          )
+            } else {
+                return [temperature, unit].joined(separator: degreeString)
+            }
+        }
     }
 }

--- a/DatWeatherDoe/UI/Decorator/Text/Temperature/TemperatureHelpers.swift
+++ b/DatWeatherDoe/UI/Decorator/Text/Temperature/TemperatureHelpers.swift
@@ -51,18 +51,8 @@ final class TemperatureHelpers {
         isUnitLetterOff: Bool,
         isUnitSymbolOff: Bool
     ) -> String {
-        if isUnitLetterOff {
-            if isUnitSymbolOff {
-                return [temperature,   ""].joined(separator: ""          )
-            } else {
-                return [temperature,   ""].joined(separator: degreeString)
-            }
-        } else {
-            if isUnitSymbolOff {
-                return [temperature, unit].joined(separator: ""          )
-            } else {
-                return [temperature, unit].joined(separator: degreeString)
-            }
-        }
+        let unitLetter = isUnitLetterOff ? "" : unit
+        let unitSymbol = isUnitSymbolOff ? "" : degreeString
+        return [temperature, unitLetter].joined(separator: unitSymbol)
     }
 }

--- a/DatWeatherDoe/UI/Decorator/Text/Temperature/TemperatureTextBuilder.swift
+++ b/DatWeatherDoe/UI/Decorator/Text/Temperature/TemperatureTextBuilder.swift
@@ -11,6 +11,8 @@ final class TemperatureTextBuilder {
     struct Options {
         let unit: TemperatureUnit
         let isRoundingOff: Bool
+        let isUnitLetterOff: Bool
+        let isUnitSymbolOff: Bool
     }
     
     private let initial: String?
@@ -32,7 +34,9 @@ final class TemperatureTextBuilder {
         let temperature = TemperatureHelpers.getTemperatureWithDegrees(
             response.temperatureData.temperature,
             unit: options.unit,
-            isRoundingOff: options.isRoundingOff
+            isRoundingOff: options.isRoundingOff,
+            isUnitLetterOff: options.isUnitLetterOff,
+            isUnitSymbolOff: options.isUnitSymbolOff
         )
         return [initial, temperature]
             .compactMap { $0 }

--- a/DatWeatherDoe/UI/Menu Bar/StatusItemManager.swift
+++ b/DatWeatherDoe/UI/Menu Bar/StatusItemManager.swift
@@ -13,6 +13,8 @@ final class StatusItemManager {
     struct Options {
         let unit: MeasurementUnit
         let isRoundingOff: Bool
+        let isUnitLetterOff: Bool
+        let isUnitSymbolOff: Bool
     }
 
     var button: NSStatusBarButton? { statusItem.button }
@@ -125,7 +127,11 @@ final class StatusItemManager {
     private func getWeatherTextFrom(weatherData: WeatherData, options: Options) -> String {
         TemperatureForecastTextBuilder(
             temperatureData: weatherData.temperatureData,
-            options: .init(unit: options.unit.temperatureUnit, isRoundingOff: options.isRoundingOff)
+            options: .init(unit: options.unit.temperatureUnit,
+              isRoundingOff: options.isRoundingOff,
+              isUnitLetterOff: options.isUnitLetterOff,
+              isUnitSymbolOff: options.isUnitSymbolOff
+              )
         ).build()
     }
 

--- a/DatWeatherDoe/ViewModel/WeatherViewModel.swift
+++ b/DatWeatherDoe/ViewModel/WeatherViewModel.swift
@@ -13,7 +13,7 @@ import OSLog
 final class WeatherViewModel: WeatherViewModelType {
 
     weak var delegate: WeatherViewModelDelegate?
-    
+
     private let configManager: ConfigManagerType
     private let errorLabels = ErrorLabels()
     private let weatherTimerSerialQueue = DispatchQueue(label: "Weather Timer Serial Queue")
@@ -55,7 +55,7 @@ final class WeatherViewModel: WeatherViewModelType {
 
     private func getWeatherWithSelectedSource() {
         let weatherSource = WeatherSource(rawValue: configManager.weatherSource) ?? .location
-        
+
         switch weatherSource {
         case .location:
             getWeatherAfterUpdatingLocation()
@@ -75,7 +75,7 @@ final class WeatherViewModel: WeatherViewModelType {
             delegate?.didFailToUpdateWeatherData(errorLabels.latLongErrorString)
             return
         }
-        
+
         weatherTask?.cancel()
         weatherTask = Task {
             do {
@@ -135,7 +135,9 @@ final class WeatherViewModel: WeatherViewModelType {
             isWeatherConditionAsTextEnabled: configManager.isWeatherConditionAsTextEnabled,
             temperatureOptions: .init(
                 unit: unit.temperatureUnit,
-                isRoundingOff: configManager.isRoundingOffData
+                isRoundingOff: configManager.isRoundingOffData,
+                isUnitLetterOff: configManager.isUnitLetterOff,
+                isUnitSymbolOff: configManager.isUnitSymbolOff
             ),
             isShowingHumidity: configManager.isShowingHumidity
         )
@@ -155,7 +157,7 @@ final class WeatherViewModel: WeatherViewModelType {
             }
         }
     }
-    
+
     private var measurementUnit: MeasurementUnit {
         MeasurementUnit(rawValue: configManager.measurementUnit) ?? .imperial
     }

--- a/DatWeatherDoeTests/Config/ConfigManagerTests.swift
+++ b/DatWeatherDoeTests/Config/ConfigManagerTests.swift
@@ -72,11 +72,32 @@ final class ConfigManagerTests: XCTestCase {
         XCTAssertEqual(configManager.isRoundingOffData, false)
     }
 
+    func testDefaultUnitLetterOffOffData() {
+        XCTAssertEqual(configManager.isUnitLetterOff, false)
+    }
+
+    func testDefaultisUnitSymbolOff() {
+        XCTAssertEqual(configManager.isUnitSymbolOff, false)
+    }
+
     func testRoundingOffDataSaved() {
         XCTAssertEqual(configManager.isRoundingOffData, false)
         configManager.isRoundingOffData = true
         XCTAssertEqual(configManager.isRoundingOffData, true)
     }
+
+    func testUnitLetterOffSaved() {
+        XCTAssertEqual(configManager.isUnitLetterOff, false)
+        configManager.isUnitLetterOff = true
+        XCTAssertEqual(configManager.isUnitLetterOff, true)
+    }
+
+    func testUnitSymbolOffSaved() {
+        XCTAssertEqual(configManager.isUnitSymbolOff, false)
+        configManager.isUnitSymbolOff = true
+        XCTAssertEqual(configManager.isUnitSymbolOff, true)
+    }
+
 
     func testWeatherConditionAsTextDefault() {
         XCTAssertEqual(configManager.isWeatherConditionAsTextEnabled, false)


### PR DESCRIPTION
<img width="54" alt="weather1" src="https://github.com/inderdhir/DatWeatherDoe/assets/12956286/5c0e0ee9-56c2-4f88-a36d-0258fe02870a">
→ 
<img width="54" alt="weather2" src="https://github.com/inderdhir/DatWeatherDoe/assets/12956286/8e51b108-ac82-4abc-be81-110d07ff3133">

to align with the simple nature of the menu bar and save precious space. The degree letter is only set once to whatever you need, so you never need it as a reminder. Likewise for degrees - if you only have one number, it's obvious it's °


