### PR TITLE
Allow custom separator

### DIFF
--- a/DatWeatherDoe/AppDelegate.swift
+++ b/DatWeatherDoe/AppDelegate.swift
@@ -90,7 +90,8 @@ extension AppDelegate: WeatherViewModelDelegate {
                 unit: measurementUnit,
                 isRoundingOff: configManager.isRoundingOffData,
                 isUnitLetterOff: configManager.isUnitLetterOff,
-                isUnitSymbolOff: configManager.isUnitSymbolOff
+                isUnitSymbolOff: configManager.isUnitSymbolOff,
+                valueSeparator: configManager.valueSeparator
             )
         )
     }

--- a/DatWeatherDoe/Config/ConfigManager.swift
+++ b/DatWeatherDoe/Config/ConfigManager.swift
@@ -74,7 +74,7 @@ final class ConfigManager: ConfigManagerType {
     @Storage(key: DefaultsKeys.isUnitSymbolOff.rawValue, defaultValue: false)
     public var isUnitSymbolOff: Bool
 
-    @Storage(key: DefaultsKeys.valueSeparator.rawValue, defaultValue: " \u{007C} ")
+    @Storage(key: DefaultsKeys.valueSeparator.rawValue, defaultValue: "\u{007C}")
     public var valueSeparator: String
 
     @Storage(

--- a/DatWeatherDoe/Config/ConfigManager.swift
+++ b/DatWeatherDoe/Config/ConfigManager.swift
@@ -18,6 +18,7 @@ protocol ConfigManagerType: AnyObject {
     var isRoundingOffData: Bool { get set }
     var isUnitLetterOff: Bool { get set }
     var isUnitSymbolOff: Bool { get set }
+    var valueSeparator: String { get set }
     var isWeatherConditionAsTextEnabled: Bool { get set }
 }
 
@@ -33,6 +34,7 @@ final class ConfigManager: ConfigManagerType {
         case isRoundingOffData
         case isUnitLetterOff
         case isUnitSymbolOff
+        case valueSeparator
         case isWeatherConditionAsTextEnabled
     }
 
@@ -71,6 +73,9 @@ final class ConfigManager: ConfigManagerType {
 
     @Storage(key: DefaultsKeys.isUnitSymbolOff.rawValue, defaultValue: false)
     public var isUnitSymbolOff: Bool
+
+    @Storage(key: DefaultsKeys.valueSeparator.rawValue, defaultValue: " \u{007C} ")
+    public var valueSeparator: String
 
     @Storage(
         key: DefaultsKeys.isWeatherConditionAsTextEnabled.rawValue,

--- a/DatWeatherDoe/UI/Configure/ConfigurationCommitter.swift
+++ b/DatWeatherDoe/UI/Configure/ConfigurationCommitter.swift
@@ -25,6 +25,7 @@ final class ConfigurationCommitter {
         isRoundingOffData: Bool,
         isUnitLetterOff: Bool,
         isUnitSymbolOff: Bool,
+        valueSeparator: String,
         isWeatherConditionAsTextEnabled: Bool
     ) {
         configManager.refreshInterval = refreshInterval.rawValue
@@ -32,6 +33,7 @@ final class ConfigurationCommitter {
         configManager.isRoundingOffData = isRoundingOffData
         configManager.isUnitLetterOff = isUnitLetterOff
         configManager.isUnitSymbolOff = isUnitSymbolOff
+        configManager.valueSeparator = valueSeparator
         configManager.isWeatherConditionAsTextEnabled = isWeatherConditionAsTextEnabled
     }
 }

--- a/DatWeatherDoe/UI/Configure/ConfigureView.swift
+++ b/DatWeatherDoe/UI/Configure/ConfigureView.swift
@@ -91,6 +91,15 @@ struct ConfigureView: View {
                 }
 
                 HStack {
+                    Text(LocalizedStringKey("Separate values with"))
+                    Spacer()
+                    TextField(viewModel.valueSeparatorPlaceholder, text: $viewModel.valueSeparator)
+                        .font(.body)
+                        .foregroundColor(.primary)
+                        .frame(width: 114)
+                }
+
+                HStack {
                     Text(LocalizedStringKey("Weather Condition (as text)"))
                     Spacer()
                     Toggle(isOn: $viewModel.isWeatherConditionAsTextEnabled) {}

--- a/DatWeatherDoe/UI/Configure/ConfigureViewModel.swift
+++ b/DatWeatherDoe/UI/Configure/ConfigureViewModel.swift
@@ -69,6 +69,14 @@ final class ConfigureViewModel: ObservableObject {
         }
     }
 
+    @Published private(set) var valueSeparatorHint = ""
+    @Published private(set) var valueSeparatorPlaceholder = "\u{007C}"
+    @Published var valueSeparator = "" {
+        didSet {
+            configManager.valueSeparator = valueSeparator
+        }
+    }
+
     @Published var isWeatherConditionAsTextEnabled: Bool {
         didSet {
             configManager.isWeatherConditionAsTextEnabled = isWeatherConditionAsTextEnabled
@@ -132,6 +140,7 @@ final class ConfigureViewModel: ObservableObject {
             isRoundingOffData: isRoundingOffData,
             isUnitLetterOff: isUnitLetterOff,
             isUnitSymbolOff: isUnitSymbolOff,
+            valueSeparator: valueSeparator,
             isWeatherConditionAsTextEnabled: isWeatherConditionAsTextEnabled
         )
     }

--- a/DatWeatherDoe/UI/Decorator/Text/Humidity/HumidityTextBuilder.swift
+++ b/DatWeatherDoe/UI/Decorator/Text/Humidity/HumidityTextBuilder.swift
@@ -12,6 +12,7 @@ import OSLog
 final class HumidityTextBuilder {
     
     private let initial: String
+    private let valueSeparator: String
     private let humidity: Int
     private let logger: Logger
     private let percentString = "\u{0025}"
@@ -25,10 +26,12 @@ final class HumidityTextBuilder {
     
     init(
         initial: String,
+        valueSeparator: String,
         humidity: Int,
         logger: Logger
     ) {
         self.initial = initial
+        self.valueSeparator = valueSeparator
         self.humidity = humidity
         self.logger = logger
     }
@@ -40,7 +43,7 @@ final class HumidityTextBuilder {
             return initial
         }
         
-        return "\(initial) | \(humidityString)"
+        return "\(initial) \(valueSeparator) \(humidityString)"
     }
     
     private func buildHumidity() -> String? {

--- a/DatWeatherDoe/UI/Decorator/Text/WeatherTextBuilder.swift
+++ b/DatWeatherDoe/UI/Decorator/Text/WeatherTextBuilder.swift
@@ -12,6 +12,7 @@ final class WeatherTextBuilder {
     
     struct Options {
         let isWeatherConditionAsTextEnabled: Bool
+        let valueSeparator: String
         let temperatureOptions: TemperatureTextBuilder.Options
         let isShowingHumidity: Bool
     }
@@ -58,6 +59,7 @@ final class WeatherTextBuilder {
         
         return HumidityTextBuilder(
             initial: initial,
+            valueSeparator: options.valueSeparator,
             humidity: response.humidity,
             logger: logger
         ).build()

--- a/DatWeatherDoe/UI/Menu Bar/StatusItemManager.swift
+++ b/DatWeatherDoe/UI/Menu Bar/StatusItemManager.swift
@@ -15,6 +15,7 @@ final class StatusItemManager {
         let isRoundingOff: Bool
         let isUnitLetterOff: Bool
         let isUnitSymbolOff: Bool
+        let valueSeparator: String
     }
 
     var button: NSStatusBarButton? { statusItem.button }

--- a/DatWeatherDoe/ViewModel/WeatherViewModel.swift
+++ b/DatWeatherDoe/ViewModel/WeatherViewModel.swift
@@ -133,6 +133,7 @@ final class WeatherViewModel: WeatherViewModelType {
     private func buildWeatherTextOptions(for unit: MeasurementUnit) -> WeatherTextBuilder.Options {
         .init(
             isWeatherConditionAsTextEnabled: configManager.isWeatherConditionAsTextEnabled,
+            valueSeparator: configManager.valueSeparator,
             temperatureOptions: .init(
                 unit: unit.temperatureUnit,
                 isRoundingOff: configManager.isRoundingOffData,


### PR DESCRIPTION
Builds upon https://github.com/inderdhir/DatWeatherDoe/pull/119 to add a bit more customization to reduce a bit more used space - replaces hardcoded ` | ` separator with a user customizable one (blank works fine, there is still enough whitespace to separate numbers)