### PR TITLE
Shorten error messages

### DIFF
--- a/DatWeatherDoe/Resources/Localization/ja.lproj/Localizable.strings
+++ b/DatWeatherDoe/Resources/Localization/ja.lproj/Localizable.strings
@@ -101,7 +101,7 @@
 "Lat/Long" = "緯度/経度";
 
 /* Lat/Long error when fetching weather */
-"Lat/Long Error" = "緯度/経度のエラー";
+"❗️Lat/Long " = "緯度/経度のエラー";
 
 /* Launch app at login */
 "Launch at Login" = "ログイン時に起動";
@@ -110,10 +110,7 @@
 "Location" = "所在地";
 
 /* Location error when fetching weather */
-"Location Error" = "所在地のエラー";
-
-/* Network error when fetching weather */
-"Network Error" = "ネットワークのエラー";
+"❗️Location " = "所在地のエラー";
 
 /* Weather refresh interval */
 "Refresh Interval" = "再読み込み間隔";

--- a/DatWeatherDoe/UI/ErrorLabels.swift
+++ b/DatWeatherDoe/UI/ErrorLabels.swift
@@ -9,12 +9,11 @@
 import Foundation
 
 final class ErrorLabels {
-    lazy var networkErrorString =
-    NSLocalizedString("Network Error", comment: "Network error when fetching weather")
+    lazy var networkErrorString = "🖧" // "Network error when fetching weather"
     lazy var locationErrorString =
-    NSLocalizedString("Location Error", comment: "Location error when fetching weather")
+    NSLocalizedString("❗️Location ", comment: "Location error when fetching weather")
     lazy var latLongErrorString =
-    NSLocalizedString("Lat/Long Error", comment: "Lat/Long error when fetching weather")
+    NSLocalizedString("❗️Lat/Long ", comment: "Lat/Long error when fetching weather")
     lazy var cityErrorString =
-    NSLocalizedString("City Error", comment: "City error when fetching weather")
+    NSLocalizedString("❗️City ", comment: "City error when fetching weather")
 }


### PR DESCRIPTION
Current error messages are too large to be displayed in the menubar, especially the network error as that can be more frequent, so it's better if it takes as little space as possible, so shortened it to just 1 symbol

Shortened other errors as well, but maybe the best would be to just have 1 symbol ❗️ and show details (location, lat, etc) in details